### PR TITLE
finalizado exceptions essenciais

### DIFF
--- a/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/ConflictException.java
+++ b/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/ConflictException.java
@@ -1,0 +1,14 @@
+package br.com.apigestao.domain.exceptions;
+
+import br.com.apigestao.core.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends BaseException {
+    public ConflictException(String message) {
+        super(message, HttpStatus.CONFLICT);
+    }
+
+    public ConflictException() {
+        this("Already Exists");
+    }
+}

--- a/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/InvalidException.java
+++ b/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/InvalidException.java
@@ -1,0 +1,14 @@
+package br.com.apigestao.domain.exceptions;
+
+import br.com.apigestao.core.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidException extends BaseException {
+    public InvalidException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+
+    public InvalidException() {
+        this("Invalid");
+    }
+}

--- a/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/NotFoundException.java
+++ b/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/NotFoundException.java
@@ -1,0 +1,14 @@
+package br.com.apigestao.domain.exceptions;
+
+import br.com.apigestao.core.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends BaseException {
+    public NotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundException() {
+        this("Not Found");
+    }
+}

--- a/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/ServerException.java
+++ b/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/ServerException.java
@@ -1,0 +1,14 @@
+package br.com.apigestao.domain.exceptions;
+
+import br.com.apigestao.core.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ServerException extends BaseException {
+    public ServerException(String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public ServerException() {
+        this("Internal Error");
+    }
+}

--- a/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/UnauthorizedException.java
+++ b/api-gestao/src/main/java/br/com/apigestao/domain/exceptions/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package br.com.apigestao.domain.exceptions;
+
+import br.com.apigestao.core.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseException {
+    public UnauthorizedException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException() {
+        this("Unauthorized");
+    }
+}


### PR DESCRIPTION

Adicionado:
Exceções genéricas para validações de regras de negócio com mensagem personalizada.
	•	InvalidException 
	•	ConflictException
	•	NotFoundException
	•	ServerException
	•	UnauthorizedException

Como usar:
	A InvalidException pode ser utilizada para suprir as seguintes validações no serviço de contas:
	•	Não permitir valor negativo na conta: Lançar a exceção quando o valor da conta for menor que 0.
	•	Garantir que a conta esteja associada a um cliente: Lançar a exceção quando a conta não tiver um cliente associado.
	•	Prevenir a criação de contas com a situação CANCELADA: Lançar a exceção quando a conta estiver com status CANCELADA.
